### PR TITLE
fix: Adding Multiple Articles For Transaction

### DIFF
--- a/library_management/hooks.py
+++ b/library_management/hooks.py
@@ -122,13 +122,13 @@ app_license = "mit"
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-# 	"*": {
-# 		"on_update": "method",
-# 		"on_cancel": "method",
-# 		"on_trash": "method"
-# 	}
-# }
+doc_events = {
+	"User": {
+		"after_insert":"library_management.library_management.doc_events.user.user.new_user_document",
+        "validate" : "library_management.library_management.doc_events.user.user.new_roleprofile"
+
+	}
+}
 
 # Scheduled Tasks
 # ---------------
@@ -226,4 +226,3 @@ app_license = "mit"
 # default_log_clearing_doctypes = {
 # 	"Logging DocType Name": 30  # days to retain logs
 # }
-

--- a/library_management/library_management/doctype/article/article.json
+++ b/library_management/library_management/doctype/article/article.json
@@ -10,12 +10,14 @@
   "article_name",
   "image",
   "author",
+  "number_of_copies",
   "description",
   "isbn",
   "status",
   "publisher",
+  "published",
   "route",
-  "published"
+  "amended_from"
  ],
  "fields": [
   {
@@ -34,7 +36,8 @@
   {
    "fieldname": "author",
    "fieldtype": "Data",
-   "label": "Author"
+   "label": "Author",
+   "reqd": 1
   },
   {
    "fieldname": "description",
@@ -47,10 +50,12 @@
    "label": "ISBN"
   },
   {
+   "default": "Available",
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Issued\nAvailable"
+   "options": "Issued\nAvailable",
+   "reqd": 1
   },
   {
    "fieldname": "publisher",
@@ -67,13 +72,29 @@
    "fieldname": "published",
    "fieldtype": "Check",
    "label": "published"
+  },
+  {
+   "fieldname": "number_of_copies",
+   "fieldtype": "Data",
+   "label": "Number of copies",
+   "reqd": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Article",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "has_web_view": 1,
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2024-05-17 14:46:42.390007",
+ "modified": "2024-05-27 11:46:35.620627",
  "modified_by": "Administrator",
  "module": "Library Management",
  "name": "Article",
@@ -97,5 +118,6 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
- "title_field": "article_name"
+ "title_field": "article_name",
+ "track_seen": 1
 }

--- a/library_management/library_management/doctype/library_member/library_member.json
+++ b/library_management/library_management/doctype/library_member/library_member.json
@@ -9,7 +9,10 @@
   "last_name",
   "full_name",
   "email_address",
-  "phone"
+  "article_issued",
+  "phone",
+  "status",
+  "count"
  ],
  "fields": [
   {
@@ -33,17 +36,36 @@
   {
    "fieldname": "email_address",
    "fieldtype": "Data",
-   "label": "Email Address"
+   "label": "Email Address",
+   "options": "Email"
   },
   {
    "fieldname": "phone",
    "fieldtype": "Data",
    "label": "Phone"
+  },
+  {
+   "default": "Deactive",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Active\nDeactive"
+  },
+  {
+   "fieldname": "article_issued",
+   "fieldtype": "Table",
+   "label": "Article issued",
+   "options": "Article Stock"
+  },
+  {
+   "fieldname": "count",
+   "fieldtype": "Data",
+   "label": "Article Count"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-05-13 10:38:27.955181",
+ "modified": "2024-05-28 11:50:41.225526",
  "modified_by": "Administrator",
  "module": "Library Management",
  "name": "Library Member",

--- a/library_management/library_management/doctype/library_member/library_member.py
+++ b/library_management/library_management/doctype/library_member/library_member.py
@@ -2,17 +2,17 @@
 # For license information, please see license.txt
 
 # import frappe
+import frappe
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
 
-
 class LibraryMember(Document):
-	#this method will run every time a document is saved
     def before_save(self):
+        # Set the full name
         self.full_name = f'{self.first_name} {self.last_name or ""}'
 
-
     def autoname(self):
+        format = "LM-{}-.####".format(self.first_name)
+        self.name = make_autoname(format)
 
-       format = "LM-{}-.####".format(self.first_name)
-       self.name = make_autoname(format)
+    

--- a/library_management/library_management/doctype/library_membership/library_membership.json
+++ b/library_management/library_management/doctype/library_membership/library_membership.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:full_name",
  "creation": "2024-05-03 11:13:52.845642",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -31,12 +32,14 @@
   {
    "fieldname": "from_date",
    "fieldtype": "Date",
-   "label": "From Date"
+   "label": "From Date",
+   "reqd": 1
   },
   {
    "fieldname": "to_date",
    "fieldtype": "Date",
-   "label": "To Date"
+   "label": "To Date",
+   "reqd": 1
   },
   {
    "default": "0",
@@ -58,11 +61,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-05-13 11:15:45.499491",
+ "modified": "2024-05-25 21:05:40.219582",
  "modified_by": "Administrator",
  "module": "Library Management",
  "name": "Library Membership",
- "naming_rule": "By script",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/library_management/library_management/doctype/library_transaction/library_transaction.js
+++ b/library_management/library_management/doctype/library_transaction/library_transaction.js
@@ -7,38 +7,6 @@
 // 	},
 // });
 frappe.ui.form.on('Library Transaction', {
-    refresh: function(frm) {
-        frm.add_custom_button('Fine', () => {
-          d = new frappe.ui.Dialog({
-              title: 'Pay Fine',
-              fields: [
-                  {
-                      label: 'Amount',
-                      fieldname: 'amount',
-                      fieldtype: 'Currency'
-                  },
-                  {
-                      label: 'Date',
-                      fieldname: 'date',
-                      fieldtype: 'Date'
-                  }
-
-              ],
-              size: 'small',
-              primary_action_label: 'Paid',
-              primary_action(values) {
-                  console.log(values);
-                  d.hide();
-              }
-          });
-
-          d.show();
-
-        })
-
-
-      },
-
 
         has_fine: function(frm){
           add_create_fine_button(frm);

--- a/library_management/library_management/doctype/library_transaction/library_transaction.json
+++ b/library_management/library_management/doctype/library_transaction/library_transaction.json
@@ -1,13 +1,13 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "LT.#####",
+ "autoname": "LM.#####",
  "creation": "2024-05-03 15:05:06.743375",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "articles",
   "library_member",
+  "articles",
   "type",
   "date",
   "amended_from",
@@ -18,14 +18,18 @@
   {
    "fieldname": "library_member",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Library Member",
-   "options": "Library Member"
+   "options": "Library Member",
+   "reqd": 1
   },
   {
    "fieldname": "type",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Type",
-   "options": "Issue\nReturn"
+   "options": "Issue\nReturn",
+   "reqd": 1
   },
   {
    "fieldname": "date",
@@ -66,11 +70,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-05-20 16:57:02.739664",
+ "modified": "2024-05-27 09:13:54.418491",
  "modified_by": "Administrator",
  "module": "Library Management",
  "name": "Library Transaction",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "By script",
  "owner": "Administrator",
  "permissions": [
   {
@@ -100,5 +104,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "library_member"
 }

--- a/library_management/library_management/doctype/library_transaction/library_transaction.py
+++ b/library_management/library_management/doctype/library_transaction/library_transaction.py
@@ -3,57 +3,125 @@
 
 # import frappe
 
+# Copyright (c) 2024, neha and contributors
+# For license information, please see license.txt
+
+# import frappe
+
 import frappe
 from frappe.model.document import Document
 from datetime import timedelta
-
+from frappe.model.naming import make_autoname
 
 class LibraryTransaction(Document):
     def before_submit(self):
         if self.type == "Issue":
             self.validate_issue()
             self.validate_maximum_limit()
-            # set the article status to be Issued
             for article in self.articles:
-                article = frappe.get_doc("Article",article.article)
-                article.status = "Issued"
+                article = frappe.get_doc("Article", article.article)
+                # article.number_of_copies = int(article.number_of_copies ) - 1
+                if article.number_of_copies == 0:
+                    article.status = "Issued"
+                else:
+                    article.status = "Available"
                 article.save()
+                self.update_issued_books(add=True)
 
         elif self.type == "Return":
             self.validate_return()
-            # set the article status to be Available
             for article in self.articles:
                 article = frappe.get_doc("Article", article.article)
+                # article.number_of_copies = int(article.number_of_copies ) + 1
                 article.status = "Available"
                 article.save()
+            self.update_issued_books(add=False)
 
     def validate_issue(self):
-        self.validate_membership()
-
-         # article cannot be issued if it is already issued
-        for article in self.articles:
-            article = frappe.get_doc("Article", article.article)
-            if article.status == "Issued":
-                frappe.throw("Article is already issued by another member")
+        for row in self.get('articles'):
+            article = frappe.get_doc("Article", row.article)
+            if article.number_of_copies == 0:
+                frappe.throw(f"No available copies of {article.name} to issue")
 
     def validate_return(self):
+        library_member = frappe.get_doc("Library Member", self.library_member)
+        article_issued = library_member.get("article_issued") or []
         for article in self.articles:
-            article = frappe.get_doc("Article",article.article)
-        # article cannot be returned if it is not issued first
-            if article.status == "Available":
-                frappe.throw("Article cannot be returned without being issued first")
+            if not any(book.article_name == article.article and not book.get('return_date') for book in article_issued):
+                frappe.throw(" Article cannot be returned as without issuing first")
+        for row in self.get('articles'):
+            for book in article_issued:
+                if book.article_name == row.article and not book.get('return_date'):
+                    library_member.count = int(library_member.count) - 1
+                    book.return_date = self.date
+                    break
+        library_member.save()
+
+    def on_cancel(self):
+        if self.type == "Issue":
+            library_member = frappe.get_doc("Library Member", self.library_member)
+            article_issued = library_member.get("article_issued") or []
+            for row in self.get('articles'):
+                article = frappe.get_doc("Article", row.article)
+                article.number_of_copies = int(article.number_of_copies) + 1
+                article.save()
+                for book in article_issued:
+                    if book.article_name == row.article and not book.get('return_date'):
+                        article_issued.remove(book)
+                        break
+            library_member.count -= len(self.get('articles'))
+            library_member.set("article_issued", article_issued)
+            library_member.save()
+        elif self.type == "Return":
+            library_member = frappe.get_doc("Library Member", self.library_member)
+            article_issued = library_member.get("article_issued") or []
+            for row in self.get('articles'):
+                article = frappe.get_doc("Article", row.article)
+                article.number_of_copies = int(article.number_of_copies) - 1
+                article.status = "Issued"
+                article.save()
+                for book in article_issued:
+                    if book.article_name == row.article and book.get('return_date') == self.date:
+                        book.return_date = None
+                        break
+            library_member.count = int(library_member.count) + 1
+            library_member.save()
+
+    def update_issued_books(self, add):
+        library_member = frappe.get_doc("Library Member", self.library_member)
+        if add:
+            for row in self.get('articles'):
+                article = frappe.get_doc("Article", row.article)
+                if article.number_of_copies == 0:
+                    frappe.throw(f"No available copies of {article.name} to issue")
+                article.number_of_copies = int(article.number_of_copies) - 1
+                article.save()
+                library_member.append("article_issued", {
+                    "article_name": article.name,
+                })
+        else:
+            for row in self.get('articles'):
+                for i, book in enumerate(library_member.get("article_issued", [])):
+                    if book.article_name == row.article and not book.get('return_date'):
+                        article = frappe.get_doc("Article", book.article_name)
+                        article.number_of_copies = int(article.number_of_copies) + 1
+                        article.save()
+                        library_member.get("article_issued").pop(i)
+                        break
+        library_member.count = len([book for book in library_member.get("article_issued", []) if not book.get('return_date')])
+        library_member.save()
 
     def validate_maximum_limit(self):
         max_articles = frappe.db.get_single_value("Library Settings", "max_articles")
-        count = frappe.db.count(
-            "Library Transaction",
-            {"library_member": self.library_member, "type": "Issue", "docstatus": 1},
-        )
-        if count + len(self.articles) > max_articles:
-            frappe.throw("Maximum limit reached for issuing articles")
+        library_member = frappe.get_doc("Library Member", self.library_member)
+        article_issued = library_member.get("article_issued") or []
+        count = len([book for book in article_issued  if not book.get('return_date')])
+        new_issues_count = len(self.get('articles'))
+        total_count = count + new_issues_count
+        if total_count > max_articles:
+            frappe.throw("The total count of issued articles exceeds the maximum limit")
 
     def validate_membership(self):
-        # check if a valid membership exist for this library member
         valid_membership = frappe.db.exists(
             "Library Membership",
             {
@@ -66,13 +134,8 @@ class LibraryTransaction(Document):
         if not valid_membership:
             frappe.throw("The member does not have a valid membership")
 
-
-
-
-
     def before_save(self):
          self.has_fine = self.check_fine_status()
-
 
     @frappe.whitelist()
     def check_fine_status(self):
@@ -83,11 +146,8 @@ class LibraryTransaction(Document):
                        "docstatus": 1,
                        "type": "Issue",
             })
-            print("\n", issue_doc,"\n ")
             issue_date = frappe.db.get_value("Library Transaction",issue_doc,'date')
             return_date = self.date
             date_diff = frappe.utils.date_diff(return_date ,issue_date )
-            print("\n", date_diff,"\n ")
             if date_diff > loan_period :
                return 1
-            return 0


### PR DESCRIPTION
here i added hooks user creation and setting and if user role librarian selected only once and the adding multiple article for transaction for a library member this obtained by creating child table into the library member and the only adding the count field and adding row and count based on each transaction done by library member both issue and return.